### PR TITLE
Ignore file change events to "index.lock" and ".git" when invalidatin…

### DIFF
--- a/src/GitStatusCache/src/CacheInvalidator.h
+++ b/src/GitStatusCache/src/CacheInvalidator.h
@@ -23,6 +23,11 @@ private:
 	boost::shared_mutex m_tokensToRepositoriesMutex;
 
 	/**
+	* Checks if the file change can be safely ignored.
+	*/
+	static bool ShouldIgnoreFileChange(const boost::filesystem::path& path);
+
+	/**
 	* Handles file change notifications by invalidating cache entries and scheduling priming.
 	*/
 	void OnFileChanged(DirectoryMonitor::Token token, const boost::filesystem::path& path, DirectoryMonitor::FileAction action);


### PR DESCRIPTION
…g cache.

Possible fix for #16 to prevent invalidation on commands like "git status" that don't require invalidation. Requires testing to confirm there isn't a case where this results in a stale cache entry.