### PR TITLE
Report UpstreamGone.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,8 @@ ipch/
 *.opensdf
 *.sdf
 *.cachefile
+*.VC.opendb
+*.VC.db
 
 # Visual Studio profiler
 *.psess

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Retrieves current status information for the requested "Path".
 		"State" : "",
 		"Branch" : "master",
 		"Upstream": "origin/master",
+		"UpstreamGone": false,
 		"AheadBy": 0,
 		"BehindBy": 0,
 		"IndexAdded": [],

--- a/ext/ReadDirectoryChanges/ide/ReadDirectoryChangesLib.vcxproj
+++ b/ext/ReadDirectoryChanges/ide/ReadDirectoryChangesLib.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -22,7 +22,7 @@
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
     <UseOfAtl>Static</UseOfAtl>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
@@ -31,7 +31,7 @@
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
     <UseOfAtl>Static</UseOfAtl>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/src/GitStatusCache/ide/GitStatusCache.vcxproj
+++ b/src/GitStatusCache/ide/GitStatusCache.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -19,13 +19,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src/GitStatusCache/src/Git.cpp
+++ b/src/GitStatusCache/src/Git.cpp
@@ -219,9 +219,9 @@ bool Git::GetRefStatus(Git::Status& status, UniqueGitRepository& repository)
 {
 	status.Branch = std::string();
 	status.Upstream = std::string();
+	status.UpstreamGone = false;
 	status.AheadBy = 0;
 	status.BehindBy = 0;
-	status.UpstreamGone = false;
 
 	auto head = MakeUniqueGitReference(nullptr);
 	auto result = git_repository_head(&head.get(), repository.get());
@@ -268,21 +268,44 @@ bool Git::GetRefStatus(Git::Status& status, UniqueGitRepository& repository)
 	result = git_branch_upstream(&upstream.get(), head.get());
 	if (result == GIT_ENOTFOUND)
 	{
-		Log("Git.GetRefStatus.NoUpstream", Severity::Spam)
-			<< R"(Branch does not have a remote tracking reference. { "repositoryPath": ")" << status.RepositoryPath
-			<< R"(", "localBranch": ")" << status.Branch << R"(" })";
-
-		auto upstreamName = git_buf{ 0 };
-		result = git_branch_upstream_remote(
-			&upstreamName,
+		auto upstreamRemoteName = git_buf{ 0 };
+		auto upstreamRemoteResult = git_branch_upstream_remote(
+			&upstreamRemoteName,
 			git_reference_owner(head.get()),
 			git_reference_name(head.get()));
-		if (result == GIT_OK)
+
+		auto upstreamBranchName = git_buf{ 0 };
+		auto upstreamBranchResult = git_branch_upstream_name(
+			&upstreamBranchName,
+			git_reference_owner(head.get()),
+			git_reference_name(head.get()));
+
+		auto canBuildUpstream = false;
+		if (upstreamRemoteResult == GIT_OK && upstreamBranchResult == GIT_OK)
 		{
 			Log("Git.GetRefStatus.UpstreamGone", Severity::Spam)
 				<< R"(Branch has a configured upstream that is gone. { "repositoryPath": ")" << status.RepositoryPath
 				<< R"(", "localBranch": ")" << status.Branch << R"(" })";
 			status.UpstreamGone = true;
+			canBuildUpstream = upstreamBranchName.ptr != nullptr && upstreamBranchName.size != 0;
+		}
+
+		if (canBuildUpstream)
+		{
+			const auto patternToRemove = std::string("refs/remotes/");
+			auto upstreamName = std::string(upstreamBranchName.ptr);
+			auto patternPosition = upstreamName.find(patternToRemove);
+			if (patternPosition == 0 && upstreamName.size() > patternToRemove.size())
+			{
+				upstreamName.erase(patternPosition, patternToRemove.size());
+			}
+			status.Upstream = upstreamName;
+		}
+		else
+		{
+			Log("Git.GetRefStatus.NoUpstream", Severity::Spam)
+				<< R"(Branch does not have a remote tracking reference. { "repositoryPath": ")" << status.RepositoryPath
+				<< R"(", "localBranch": ")" << status.Branch << R"(" })";
 		}
 
 		return true;

--- a/src/GitStatusCache/src/Git.cpp
+++ b/src/GitStatusCache/src/Git.cpp
@@ -268,12 +268,6 @@ bool Git::GetRefStatus(Git::Status& status, UniqueGitRepository& repository)
 	result = git_branch_upstream(&upstream.get(), head.get());
 	if (result == GIT_ENOTFOUND)
 	{
-		auto upstreamRemoteName = git_buf{ 0 };
-		auto upstreamRemoteResult = git_branch_upstream_remote(
-			&upstreamRemoteName,
-			git_reference_owner(head.get()),
-			git_reference_name(head.get()));
-
 		auto upstreamBranchName = git_buf{ 0 };
 		auto upstreamBranchResult = git_branch_upstream_name(
 			&upstreamBranchName,
@@ -281,7 +275,7 @@ bool Git::GetRefStatus(Git::Status& status, UniqueGitRepository& repository)
 			git_reference_name(head.get()));
 
 		auto canBuildUpstream = false;
-		if (upstreamRemoteResult == GIT_OK && upstreamBranchResult == GIT_OK)
+		if (upstreamBranchResult == GIT_OK)
 		{
 			Log("Git.GetRefStatus.UpstreamGone", Severity::Spam)
 				<< R"(Branch has a configured upstream that is gone. { "repositoryPath": ")" << status.RepositoryPath

--- a/src/GitStatusCache/src/Git.h
+++ b/src/GitStatusCache/src/Git.h
@@ -22,6 +22,7 @@ public:
 
 		std::string Branch;
 		std::string Upstream;
+		bool UpstreamGone = false;
 		int AheadBy = 0;
 		int BehindBy = 0;
 

--- a/src/GitStatusCache/src/StatusController.cpp
+++ b/src/GitStatusCache/src/StatusController.cpp
@@ -31,6 +31,12 @@ StatusController::~StatusController()
 	writer.String(value.c_str());
 }
 
+/*static*/ void StatusController::AddBoolToJson(rapidjson::Writer<rapidjson::StringBuffer>& writer, std::string&& name, bool value)
+{
+	writer.String(name.c_str());
+	writer.Bool(value);
+}
+
 /*static*/ void StatusController::AddUintToJson(rapidjson::Writer<rapidjson::StringBuffer>& writer, std::string&& name, uint32_t value)
 {
 	writer.String(name.c_str());
@@ -122,6 +128,7 @@ std::string StatusController::GetStatus(const rapidjson::Document& document, con
 	AddStringToJson(writer, "State", statusToReport.State.c_str());
 	AddStringToJson(writer, "Branch", statusToReport.Branch.c_str());
 	AddStringToJson(writer, "Upstream", statusToReport.Upstream.c_str());
+	AddBoolToJson(writer, "UpstreamGone", statusToReport.UpstreamGone);
 	AddUintToJson(writer, "AheadBy", statusToReport.AheadBy);
 	AddUintToJson(writer, "BehindBy", statusToReport.BehindBy);
 

--- a/src/GitStatusCache/src/StatusController.h
+++ b/src/GitStatusCache/src/StatusController.h
@@ -34,6 +34,11 @@ private:
 	static void AddStringToJson(rapidjson::Writer<rapidjson::StringBuffer>& writer, std::string&& name, std::string&& value);
 
 	/**
+	* Adds bool to JSON response.
+	*/
+	static void AddBoolToJson(rapidjson::Writer<rapidjson::StringBuffer>& writer, std::string&& name, bool value);
+
+	/**
 	* Adds uint32_t to JSON response.
 	*/
 	static void AddUintToJson(rapidjson::Writer<rapidjson::StringBuffer>& writer, std::string&& name, uint32_t value);


### PR DESCRIPTION
Report UpstreamGone. Resolves #19.

UpstreamGone is set when a branch has no remote tracking reference but still has an upstream configured. This is similar to the git warning:

Your branch is based on 'origin/master', but the upstream is gone.
  (use "git branch --unset-upstream" to fixup)